### PR TITLE
add inventory for ios devices

### DIFF
--- a/lib/ansible/module_utils/network/ios/facts/facts.py
+++ b/lib/ansible/module_utils/network/ios/facts/facts.py
@@ -23,14 +23,15 @@ from ansible.module_utils.network.ios.facts.lacp_interfaces.lacp_interfaces impo
 from ansible.module_utils.network.ios.facts.lldp_global.lldp_global import Lldp_globalFacts
 from ansible.module_utils.network.ios.facts.lldp_interfaces.lldp_interfaces import Lldp_InterfacesFacts
 from ansible.module_utils.network.ios.facts.l3_interfaces.l3_interfaces import L3_InterfacesFacts
-from ansible.module_utils.network.ios.facts.legacy.base import Default, Hardware, Interfaces, Config
+from ansible.module_utils.network.ios.facts.legacy.base import Default, Hardware, Interfaces, Config, Inventory
 
 
 FACT_LEGACY_SUBSETS = dict(
     default=Default,
     hardware=Hardware,
     interfaces=Interfaces,
-    config=Config
+    config=Config,
+    inventory=Inventory
 )
 
 FACT_RESOURCE_SUBSETS = dict(

--- a/lib/ansible/module_utils/network/ios/facts/legacy/base.py
+++ b/lib/ansible/module_utils/network/ios/facts/legacy/base.py
@@ -378,3 +378,62 @@ class Interfaces(FactsBase):
         match = re.search(r'^Device ID: (.+)$', data, re.M)
         if match:
             return match.group(1)
+        
+class Inventory(FactsBase):
+
+    COMMANDS = [
+        'show inventory'
+    ]
+
+    def populate(self):
+        super(Inventory, self).populate()
+
+        self.facts['inventory'] = list()
+
+        data = self.responses[0]
+        if data:
+            self.facts['inventory'] = self.parse_inventory(data)
+
+    def parse_inventory(self, data):
+        facts = dict()
+        key = 0
+        line = 0
+        for entry in data.split('\n'):
+            if entry == '':
+                continue
+            if key not in facts:
+                facts[key] = dict()
+            if line == 1:
+                x = { 'PID':self.parse_pid(entry), 'SN':self.parse_serial(entry) }
+                facts[key].update(x)
+                key += 1
+                line += 1
+            if line == 0:
+                x = { 'NAME':self.parse_name(entry), 'DESCR':self.parse_descr(entry) }
+                facts[key].update(x)
+                line += 1
+            if line == 2:
+                line = 0
+
+        return facts
+
+
+    def parse_name(self, data):
+        match = re.search(r'NAME: "(.+)",', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_descr(self, data):
+        match = re.search(r'DESCR: "(.+)"', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_pid(self, data):
+        match = re.search(r'PID: ([^ \s]+)', data, re.M)
+        if match:
+            return match.group(1)
+    
+    def parse_serial(self, data):
+        match = re.search(r'SN: ([^ \s]+)', data, re.M)
+        if match:
+            return match.group(1)

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -203,6 +203,12 @@ ansible_net_neighbors:
       CDP and LLDP neighbor data is present on one port, CDP is preferred.
   returned: when interfaces is configured
   type: dict
+  
+# inventory
+ansible_net_inventory:
+  description: All inventory cards on the device
+  return: when inventory is configured
+  type: list
 """
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
this will do a "show inventory" on the device and parse module cards (eg EHWIC, HWIC, VWIC etc) and give access to them with name, description, pid and serialnumber

##### SUMMARY

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME


##### ADDITIONAL INFORMATION

```
Example Router: 881G-4G

            "ansible_net_inventory": {
                "0": {
                    "DESCR": "C881G-4G-GA-K9 chassis, Hw Serial#: XXXXXXXX, Hw Revision: 1.0",
                    "NAME": "C881G-4G-GA-K9",
                    "PID": "C881G-4G-GA-K9",
                    "SN": "XXXXXXXXX"
                },
                "1": {
                    "DESCR": "C881G4G Mother board",
                    "NAME": "C881G4G Mother board on Slot 0",
                    "PID": "C881G-4G-GA-K9",
                    "SN": "XXXXXXXXX"
                },
                "2": {
                    "DESCR": "Sierra Wireless MC7304 4G-GA",
                    "NAME": "Modem 0 on Cellular0",
                    "PID": "MC7304",
                    "SN": "XXXXXXXXX"
                }
            },

Example Router: 1921/K9

            "ansible_net_inventory": {
                "0": {
                    "DESCR": "CISCO1921/K9 chassis, Hw Serial#: XXXXXXXX, Hw Revision: 1.0",
                    "NAME": "CISCO1921/K9",
                    "PID": "CISCO1921/K9",
                    "SN": "XXXXXXXXXX"
                },
                "1": {
                    "DESCR": "3G WWAN HWIC-HSPA/UMTS/EDGE/GPRS-850/900/1800/1900/2100MHz",
                    "NAME": "3G WWAN HWIC-HSPA/UMTS/EDGE/GPRS-850/900/1800/1900/2100MHz on Slot 0 SubSlot 1",
                    "PID": "HWIC-3G-HSPA",
                    "SN": "XXXXXXXXXX"
                },
                "2": {
                    "DESCR": "Sierra Wireless MC8790",
                    "NAME": "Modem 0 on Cellular0/1/0",
                    "PID": "MC8790",
                    "SN": "XXXXXXXXXXX"
                }
            },


```
